### PR TITLE
Enable GPU usage in training script

### DIFF
--- a/train.py
+++ b/train.py
@@ -1,7 +1,14 @@
 
 import os
+import torch
 from datasets import Dataset
-from transformers import (GPT2LMHeadModel, GPT2TokenizerFast, DataCollatorForLanguageModeling, Trainer, TrainingArguments)
+from transformers import (
+    GPT2LMHeadModel,
+    GPT2TokenizerFast,
+    DataCollatorForLanguageModeling,
+    Trainer,
+    TrainingArguments,
+)
 
 # Load text data
 DATA_FILE = os.path.join('data', 'harry_potter_sample.txt')
@@ -13,7 +20,8 @@ dataset = Dataset.from_dict({'text': lines})
 # Load tokenizer and model
 model_name = 'gpt2'
 tokenizer = GPT2TokenizerFast.from_pretrained(model_name)
-model = GPT2LMHeadModel.from_pretrained(model_name)
+device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
+model = GPT2LMHeadModel.from_pretrained(model_name).to(device)
 
 # Tokenize dataset
 def tokenize_function(examples):


### PR DESCRIPTION
## Summary
- add torch import to check CUDA availability
- move the model to GPU if available

## Testing
- `python -m py_compile train.py`


------
https://chatgpt.com/codex/tasks/task_e_686d4c59ff6083269c6202844f4ec8ca