### PR TITLE
Fix attention mask warning in text generation

### DIFF
--- a/query_models.py
+++ b/query_models.py
@@ -29,13 +29,22 @@ for model_dir in MODEL_DIRS:
     try:
         tokenizer = GPT2TokenizerFast.from_pretrained(model_dir)
         model = GPT2LMHeadModel.from_pretrained(model_dir)
+        tokenizer.pad_token = tokenizer.eos_token
     except Exception as e:
         print(f"Failed to load {model_dir}: {e}")
         continue
 
     for q in questions:
-        inputs = tokenizer.encode(q, return_tensors="pt")
+        encoded = tokenizer(q, return_tensors="pt")
+        input_ids = encoded["input_ids"]
+        attention_mask = encoded["attention_mask"]
         with torch.no_grad():
-            outputs = model.generate(inputs, max_length=50, num_return_sequences=1)
+            outputs = model.generate(
+                input_ids,
+                attention_mask=attention_mask,
+                max_length=50,
+                num_return_sequences=1,
+                pad_token_id=tokenizer.eos_token_id,
+            )
         answer = tokenizer.decode(outputs[0], skip_special_tokens=True)
         print(f"\nPrompt: {q}\nAnswer: {answer}\n")


### PR DESCRIPTION
## Summary
- set `pad_token` for GPT-2 tokenizer
- pass `attention_mask` and `pad_token_id` when calling `generate`

## Testing
- `python -m py_compile query_models.py`

------
https://chatgpt.com/codex/tasks/task_e_686d6285abb48326b286b0cad225c581