### PR TITLE
Switch model to Llama-2

### DIFF
--- a/train.py
+++ b/train.py
@@ -3,8 +3,8 @@ import os
 import torch
 from datasets import Dataset
 from transformers import (
-    GPT2LMHeadModel,
-    GPT2TokenizerFast,
+    AutoModelForCausalLM,
+    AutoTokenizer,
     DataCollatorForLanguageModeling,
     Trainer,
     TrainingArguments,
@@ -18,11 +18,11 @@ with open(DATA_FILE, 'r', encoding='utf-8') as f:
 dataset = Dataset.from_dict({'text': lines})
 
 # Load tokenizer and model
-model_name = 'gpt2'
-tokenizer = GPT2TokenizerFast.from_pretrained(model_name)
+model_name = 'meta-llama/Llama-2-7b-hf'
+tokenizer = AutoTokenizer.from_pretrained(model_name)
 tokenizer.pad_token = tokenizer.eos_token
 device = torch.device('cuda' if torch.cuda.is_available() else 'cpu')
-model = GPT2LMHeadModel.from_pretrained(model_name).to(device)
+model = AutoModelForCausalLM.from_pretrained(model_name).to(device)
 
 
 # Tokenize dataset
@@ -33,7 +33,7 @@ lm_dataset = dataset.map(tokenize_function, batched=True)
 
 # Training arguments
 training_args = TrainingArguments(
-    output_dir='output',
+    output_dir='llama_output',
     overwrite_output_dir=True,
     num_train_epochs=1,
     per_device_train_batch_size=1,
@@ -58,9 +58,9 @@ trainer = Trainer(
 trainer.train()
 
 # Save model
-model.save_pretrained('reinforced_model')
-tokenizer.save_pretrained('reinforced_model')
+model.save_pretrained('llama_reinforced_model')
+tokenizer.save_pretrained('llama_reinforced_model')
 
-print('Model saved to reinforced_model')
+print('Model saved to llama_reinforced_model')
 
 


### PR DESCRIPTION
## Summary
- swap GPT-2 for Llama-2 in `train.py`
- update training output directory and save path

## Testing
- `python -m py_compile train.py`


------
https://chatgpt.com/codex/tasks/task_e_686d6673613c8326b7209f4a16c37264